### PR TITLE
Measure the size of dataCode once again

### DIFF
--- a/qrcode.go
+++ b/qrcode.go
@@ -566,6 +566,7 @@ func Bits2Bytes(dataCode []bool, version int) ([]byte, error) {
 	}
 	var result []byte
 	dataCode = dataCode[lpos:hpos]
+	size = hpos - lpos + 1
 	for i := 0; i < length*8 && i < size; {
 		ipos := i + 8
 		if ipos > size-1 {


### PR DESCRIPTION
Avoid out of bounds error, measure the size of dataCode again.